### PR TITLE
Tweak home row mods

### DIFF
--- a/config/piantor_pro_bt.keymap
+++ b/config/piantor_pro_bt.keymap
@@ -62,6 +62,32 @@
         hold-trigger-key-positions = <0 1 2 3 4 5 12 13 14 15 16 17 24 25 26 27 28 29 36 37 38>;
         hold-trigger-on-release;
       };
+      /* Custom Left Shift */
+      hml_shift: hml_shift {
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        label = "HML_SHIFT";
+        bindings = <&kp>, <&kp>;
+        tapping-term-ms = <200>;
+        quick-tap-ms = <175>;
+        require-prior-idle-ms = <85>;
+        flavor = "balanced";
+        hold-trigger-key-positions = <6 7 8 9 10 11 18 19 20 21 22 23 30 31 32 33 34 35 39 40 41>;
+        hold-trigger-on-release;
+      };
+      /* Custom Right Shift */
+      hmr_shift: hmr_shift {
+        compatible = "zmk,behavior-hold-tap";
+        #binding-cells = <2>;
+        label = "HMR_SHIFT";
+        bindings = <&kp>, <&kp>;
+        tapping-term-ms = <200>;
+        quick-tap-ms = <175>;
+        require-prior-idle-ms = <85>;
+        flavor = "balanced";
+        hold-trigger-key-positions = <0 1 2 3 4 5 12 13 14 15 16 17 24 25 26 27 28 29 36 37 38>;
+        hold-trigger-on-release;
+      };
       prog_caps: prog_caps {
         compatible = "zmk,behavior-caps-word";
         #binding-cells = <0>;

--- a/config/piantor_pro_bt.keymap
+++ b/config/piantor_pro_bt.keymap
@@ -46,7 +46,7 @@
         tapping-term-ms = <280>;
         quick-tap-ms = <175>;
         require-prior-idle-ms = <125>;
-        flavor = "balanced";
+        flavor = "tap-unless-interrupted";
         hold-trigger-key-positions = <6 7 8 9 10 11 18 19 20 21 22 23 30 31 32 33 34 35 39 40 41>;
         hold-trigger-on-release;
       };
@@ -58,7 +58,7 @@
         tapping-term-ms = <280>;
         quick-tap-ms = <175>;
         require-prior-idle-ms = <125>;
-        flavor = "balanced";
+        flavor = "tap-unless-interrupted";
         hold-trigger-key-positions = <0 1 2 3 4 5 12 13 14 15 16 17 24 25 26 27 28 29 36 37 38>;
         hold-trigger-on-release;
       };

--- a/config/piantor_pro_bt.keymap
+++ b/config/piantor_pro_bt.keymap
@@ -108,8 +108,8 @@
             display-name = "colemak";
 
             bindings = <
-              &kp ESCAPE  &kp Q  &kp W  &kp F  &kp P  &kp B  &kp J  &kp L  &kp U  &kp Y  &kp SEMICOLON  &kp BSPC
-              &kp TAB  &hml LALT A  &hml LGUI R  &hml LCTRL S  &hml LSHFT T  &kp G  &kp M  &hmr RSHFT N  &hmr RCTRL E  &hmr RGUI I  &hmr RALT O  &kp SINGLE_QUOTE
+              &kp ESCAPE  &kp Q  &kp W  &kp F  &kp P  &kp B  &kp J  &kp L  &kp U  &kp Y  &kp SEMICOLON  &kp DEL
+              &kp TAB  &hml LALT A  &hml LGUI R  &hml LCTRL S  &hml_shift LSHFT T  &kp G  &kp M  &hmr_shift RSHFT N  &hmr RCTRL E  &hmr RGUI I  &hmr RALT O  &kp SINGLE_QUOTE
               &kp LCTRL  &kp X  &kp C  &kp D  &kp V  &kp Z  &kp K  &kp H  &kp COMMA  &kp PERIOD  &kp SLASH  &kp RCTRL
                          &mo 1  &kp SPACE  &sym_arrow_dance  &kp RET  &kp BACKSPACE  &mo 4
             >;
@@ -119,7 +119,7 @@
             display-name = "number";
 
             bindings = <
-              &kp TAB  &kp N1  &kp N2  &kp N3  &kp N4  &kp N5  &kp N6  &kp N7  &kp N8  &kp N9  &kp N0  &kp BSPC
+              &kp TAB  &kp N1  &kp N2  &kp N3  &kp N4  &kp N5  &kp N6  &kp N7  &kp N8  &kp N9  &kp N0  &kp DEL
               &kp F12  &kp F1  &kp F2  &kp F3  &kp F4  &kp F5  &kp F6  &kp F7  &kp F8  &kp F9  &kp F10  &kp F11
               &kp LCTRL  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans  &trans
                           &kp LGUI  &trans  &kp SPACE  &kp LGUI  &trans  &kp SPACE

--- a/config/piantor_pro_bt.keymap
+++ b/config/piantor_pro_bt.keymap
@@ -46,7 +46,7 @@
         tapping-term-ms = <280>;
         quick-tap-ms = <175>;
         require-prior-idle-ms = <125>;
-        flavor = "tap-unless-interrupted";
+        flavor = "balanced";
         hold-trigger-key-positions = <6 7 8 9 10 11 18 19 20 21 22 23 30 31 32 33 34 35 39 40 41>;
         hold-trigger-on-release;
       };
@@ -58,7 +58,7 @@
         tapping-term-ms = <280>;
         quick-tap-ms = <175>;
         require-prior-idle-ms = <125>;
-        flavor = "tap-unless-interrupted";
+        flavor = "balanced";
         hold-trigger-key-positions = <0 1 2 3 4 5 12 13 14 15 16 17 24 25 26 27 28 29 36 37 38>;
         hold-trigger-on-release;
       };


### PR DESCRIPTION
After a bit of experimentation I think this is the best solution here. This will create custom config for the left and right `shift` keys and assign lower `require-prior-idle-ms` for them. This allows for more key rolling on the same hand plus cross-hand. Generates slightly better WPM with this config. Let's see how it holds.